### PR TITLE
fix rc.pvr systemd service

### DIFF
--- a/meta-rcar-gen2/recipes-graphics/gles-module/gles-user-module.bb
+++ b/meta-rcar-gen2/recipes-graphics/gles-module/gles-user-module.bb
@@ -67,6 +67,9 @@ do_install() {
         fi
     fi
     if [ ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)} ]; then
+        # if we do not move rc.pvr, it will be remove by "rm_systemd_unitdir"
+        install -d ${D}${localedir}/bin/
+        mv ${D}/etc/init.d/rc.pvr ${D}${localedir}/bin/
         install -d ${D}/${systemd_unitdir}/system/
         install -m 644 ${WORKDIR}/rc.pvr.service ${D}/${systemd_unitdir}/system/
     fi
@@ -81,6 +84,7 @@ FILES_${PN} = " \
     ${sysconfdir}/* \
     ${libdir}/* \
     /usr/local/bin/* \
+    ${localedir}/bin/* \
 "
 
 FILES_${PN}-dev = " \

--- a/meta-rcar-gen2/recipes-graphics/gles-module/gles-user-module/rc.pvr.service
+++ b/meta-rcar-gen2/recipes-graphics/gles-module/gles-user-module/rc.pvr.service
@@ -2,11 +2,10 @@
 Description=PowerVR consumer services
 
 [Service]
-ExecStart=/etc/init.d/rc.pvr start
-ExecStop=/etc/init.d/rc.pvr stop
+ExecStart=/usr/lib/locale/bin/rc.pvr start
+ExecStop=/usr/lib/locale/bin/rc.pvr stop
 Type=oneshot
 RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
-

--- a/meta-rcar-gen3/recipes-graphics/gles-module/gles-user-module.bb
+++ b/meta-rcar-gen3/recipes-graphics/gles-module/gles-user-module.bb
@@ -64,6 +64,9 @@ do_install() {
     fi
 
     if [ ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)} ]; then
+        # if we do not move rc.pvr, it will be remove by "rm_systemd_unitdir"
+        install -d ${D}${localedir}/bin/
+        mv ${D}/etc/init.d/rc.pvr ${D}${localedir}/bin/
         install -d ${D}/${systemd_unitdir}/system/
         install -m 644 ${WORKDIR}/rc.pvr.service ${D}/${systemd_unitdir}/system/
     fi
@@ -80,8 +83,9 @@ PACKAGES = "\
 FILES_${PN} = " \
     ${sysconfdir}/* \
     ${libdir}/* \
-    /lib/firmware/rgx.fw \
+    /lib/firmware/rgx.fw \\
     /usr/local/bin/* \
+    ${localedir}/bin/* \
 "
 
 FILES_${PN}-dev = " \

--- a/meta-rcar-gen3/recipes-graphics/gles-module/gles-user-module/rc.pvr.service
+++ b/meta-rcar-gen3/recipes-graphics/gles-module/gles-user-module/rc.pvr.service
@@ -2,8 +2,8 @@
 Description=PowerVR consumer services
 
 [Service]
-ExecStart=/etc/init.d/rc.pvr start
-ExecStop=/etc/init.d/rc.pvr stop
+ExecStart=/usr/lib/locale/bin/rc.pvr start
+ExecStop=/usr/lib/locale/bin/rc.pvr stop
 Type=oneshot
 RemainAfterExit=yes
 


### PR DESCRIPTION
 * if rc.pvr is install into /etc/init.d,
   it will be remove by "rm_systemd_unitdir".

 * If you have systemd in your DISTRO_FEATURES and no sysvinit in DISTRO_FEATURES
   /etc/init.d is remove.

rm_systemd_unitdir From poky/meta/classes/systemd.bbclass:
"""
    if bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d) and \
        not bb.utils.contains('DISTRO_FEATURES', 'sysvinit', True, False, d) and \
        os.path.exists(sysv_initddir):
        systemd_system_unitdir = oe.path.join(d.getVar("D", True), d.getVar('systemd_system_unitdir', True))

        # If systemd_system_unitdir contains anything, delete sysv_initddir
        if (os.path.exists(systemd_system_unitdir) and os.listdir(systemd_system_unitdir)):
            shutil.rmtree(sysv_initddir)
"""

Signed-off-by: Ronan <ronan.lemartret@iot.bzh>