### PR TITLE
fix untar source for omx

### DIFF
--- a/meta-rcar-gen3/recipes-multimedia/omx-module/omx-user-module.bb
+++ b/meta-rcar-gen3/recipes-multimedia/omx-module/omx-user-module.bb
@@ -150,8 +150,8 @@ setup_build_tree() {
     for omxmc in ${OMX_COMMON_SRC} ${OMX_VIDEO_DEC_COMMON_SRC} ${OMX_VIDEO_ENC_COMMON_SRC}
     do
         tar xf ${WORKDIR}/${omxmc}.tar.bz2 -C ${WORKDIR}
-        tar xf ${WORKDIR}/${omxmc}.tar.bz2 ${omxmc}/src --strip=2 -C ${S}
-        tar xf ${WORKDIR}/${omxmc}.tar.bz2 ${omxmc}/include --strip=1 -C ${S}
+        tar xf ${WORKDIR}/${omxmc}.tar.bz2 -C ${S} ${omxmc}/src --strip=2 
+        tar xf ${WORKDIR}/${omxmc}.tar.bz2 -C ${S} ${omxmc}/include --strip=1
     done
 }
 


### PR DESCRIPTION
 - the option "-C" of tar must be use before the option "--strip"
   to be effective.
 - mandatory for yocto 2.2 morty

Signed-off-by: ronan@iot.bzh <ronan@iot.bzh>