### PR TITLE
replace deprecated function base_contains

### DIFF
--- a/meta-rcar-gen2/conf/machine/blanche.conf
+++ b/meta-rcar-gen2/conf/machine/blanche.conf
@@ -19,7 +19,7 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-renesas"
 PREFERRED_PROVIDER_linux-libc-headers = "linux-libc-headers"
 PREFERRED_PROVIDER_nativesdk-linux-libc-headers = "nativesdk-linux-libc-headers"
 PREFERRED_PROVIDER_u-boot = "u-boot"
-PREFERRED_PROVIDER_virtual/egl = "${@base_contains("DISTRO_FEATURES", "wayland", "libegl", "", d)}"
+PREFERRED_PROVIDER_virtual/egl = "${@bb.utils.contains("DISTRO_FEATURES", "wayland", "libegl", "", d)}"
 
 # Device tree for Blanche
 KERNEL_DEVICETREE = "${S}/arch/arm/boot/dts/r8a7792-blanche.dts"

--- a/meta-rcar-gen2/recipes-graphics/gles-module/gles-user-module.bb
+++ b/meta-rcar-gen2/recipes-graphics/gles-module/gles-user-module.bb
@@ -25,17 +25,17 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 OPENGLES3 ?= "0"
 
 SRC_URI_r8a7791 = "file://r8a7743_linux_sgx_binaries_gles2.tar.bz2"
-SRC_URI_append_r8a7791 = " ${@base_contains("DISTRO_FEATURES", "wayland", " \
+SRC_URI_append_r8a7791 = " ${@bb.utils.contains("DISTRO_FEATURES", "wayland", " \
     file://EGL_headers_for_wayland.patch \
     ", "", d)}"
 
 SRC_URI_r8a7792 = "file://r8a7792_linux_sgx_binaries_gles2.tar.bz2"
-SRC_URI_append_r8a7792 = " ${@base_contains("DISTRO_FEATURES", "wayland", " \
+SRC_URI_append_r8a7792 = " ${@bb.utils.contains("DISTRO_FEATURES", "wayland", " \
     file://EGL_headers_for_wayland.patch \
     ", "", d)}"
 
 SRC_URI_r8a7794 = "file://r8a7794_linux_sgx_binaries_gles2.tar.bz2"
-SRC_URI_append_r8a7794 = " ${@base_contains("DISTRO_FEATURES", "wayland", " \
+SRC_URI_append_r8a7794 = " ${@bb.utils.contains("DISTRO_FEATURES", "wayland", " \
     file://EGL_headers_for_wayland.patch \
     ", "", d)}"
 
@@ -90,7 +90,7 @@ FILES_${PN}-dev = " \
 inherit update-rc.d systemd
 
 PROVIDES = "virtual/libgles2"
-PROVIDES_append = "${@base_contains("DISTRO_FEATURES", "wayland", "", " virtual/egl", d)}"
+PROVIDES_append = "${@bb.utils.contains("DISTRO_FEATURES", "wayland", "", " virtual/egl", d)}"
 RPROVIDES_${PN} += "${GLES}-user-module libgles2-mesa libgles2-mesa-dev libgles2 libgles2-dev"
 INSANE_SKIP_${PN} += "ldflags already-stripped"
 INSANE_SKIP_${PN}-dev += "ldflags"

--- a/meta-rcar-gen2/recipes-graphics/wayland/libegl.bb
+++ b/meta-rcar-gen2/recipes-graphics/wayland/libegl.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://egl.c;beginline=5;endline=15;md5=3677623633a6e459b1f6
 
 COMPATIBLE_MACHINE = "(blanche|wheat)"
 
-PROVIDES = "${@base_contains("DISTRO_FEATURES", "wayland", "virtual/egl", "", d)}"
+PROVIDES = "${@bb.utils.contains("DISTRO_FEATURES", "wayland", "virtual/egl", "", d)}"
 SRCREV = "7b09cce97e8658ba927e71f1af43360c4cc392b7"
 SRC_URI = " \
     git://github.com/thayama/libegl;protocol=git;branch=master \

--- a/meta-rcar-gen2/recipes-kernel/kernel-module-gles/kernel-module-gles.bb
+++ b/meta-rcar-gen2/recipes-kernel/kernel-module-gles/kernel-module-gles.bb
@@ -26,8 +26,8 @@ S_r8a7792 = "${WORKDIR}/eurasia_km"
 KERNEL_SRC_PATH_r8a7792 = "eurasiacon/build/linux2/r8a7792_linux/"
 TARGET_PATH_r8a7792 = "eurasia_km/eurasiacon/binary2_r8a7792_linux_release/target/kbuild"
 
-GLES = "${@base_contains('MACHINE_FEATURES', 'rgx', 'rgx', \
-    base_contains('MACHINE_FEATURES', 'sgx', 'sgx', '', d), d)}"
+GLES = "${@bb.utils.contains('MACHINE_FEATURES', 'rgx', 'rgx', \
+    bb.utils.contains('MACHINE_FEATURES', 'sgx', 'sgx', '', d), d)}"
 
 RPROVIDES_${PN} += "${GLES}-kernel-module"
 

--- a/meta-rcar-gen3/recipes-core/initscripts/initscripts_%.bbappend
+++ b/meta-rcar-gen3/recipes-core/initscripts/initscripts_%.bbappend
@@ -8,7 +8,7 @@ SRC_URI_append = " \
 
 do_install_append() {
     install -d ${D}/${sysconfdir}/init.d
-    if [ "${@base_contains('MACHINE_FEATURES', 'h3ulcb-had', 'h3ulcb-had', '', d)}" = "h3ulcb-had" ]; then
+    if [ "${@bb.utils.contains('MACHINE_FEATURES', 'h3ulcb-had', 'h3ulcb-had', '', d)}" = "h3ulcb-had" ]; then
         install -m 755 ${S}/adas-switch-init ${D}/${sysconfdir}/init.d/adas-switch-init
         update-rc.d -r ${D} adas-switch-init start 5 S .
     fi

--- a/meta-rcar-gen3/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-rcar-gen3/recipes-core/systemd/systemd_%.bbappend
@@ -13,7 +13,7 @@ SRC_URI_append = " \
 "
 
 do_install_append() {
-    if [ "${@base_contains('MACHINE_FEATURES', 'h3ulcb-had', 'h3ulcb-had', '', d)}" = "h3ulcb-had" ]; then
+    if [ "${@bb.utils.contains('MACHINE_FEATURES', 'h3ulcb-had', 'h3ulcb-had', '', d)}" = "h3ulcb-had" ]; then
         if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
             install -d ${D}${systemd_unitdir}/system
             install -m 0644 ${SS}/adas-switch-init.service ${D}${systemd_unitdir}/system/


### PR DESCRIPTION
 * replace base_contains by bb.utils.contains
 * base_contains is deprecated use bb.utils.contains instead
 * yocto version: 2.2

Signed-off-by: Ronan <ronan.lemartret@iot.bzh>