### PR TITLE
Append to previously set IMAGE_FSTYPES instead of overriding it

### DIFF
--- a/meta-rcar-gen2/conf/machine/blanche.conf
+++ b/meta-rcar-gen2/conf/machine/blanche.conf
@@ -10,7 +10,7 @@ require conf/machine/include/tune-cortexa15.inc
 LINUXLIBCVERSION = "4.6"
 
 KERNEL_IMAGETYPE = "uImage"
-IMAGE_FSTYPES = "tar.bz2 ext4 cpio.gz"
+IMAGE_FSTYPES += " tar.bz2 ext4 cpio.gz"
 
 SERIAL_CONSOLE = "38400 ttySC0"
 

--- a/meta-rcar-gen2/conf/machine/wheat.conf
+++ b/meta-rcar-gen2/conf/machine/wheat.conf
@@ -10,7 +10,7 @@ require conf/machine/include/tune-cortexa15.inc
 LINUXLIBCVERSION = "4.6"
 
 KERNEL_IMAGETYPE = "uImage"
-IMAGE_FSTYPES = "tar.bz2 ext4 cpio.gz"
+IMAGE_FSTYPES += " tar.bz2 ext4 cpio.gz"
 
 SERIAL_CONSOLE = "115200 ttySC0"
 

--- a/meta-rcar-gen3/conf/machine/h3ulcb.conf
+++ b/meta-rcar-gen3/conf/machine/h3ulcb.conf
@@ -16,7 +16,7 @@ MACHINE_FEATURES = ""
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
 
 KERNEL_IMAGETYPE = "Image"
-IMAGE_FSTYPES = "tar.bz2 ext4 cpio.gz"
+IMAGE_FSTYPES += " tar.bz2 ext4 cpio.gz"
 
 SERIAL_CONSOLE = "115200 ttySC0"
 

--- a/meta-rcar-gen3/conf/machine/m3ulcb.conf
+++ b/meta-rcar-gen3/conf/machine/m3ulcb.conf
@@ -16,7 +16,7 @@ MACHINE_FEATURES = ""
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
 
 KERNEL_IMAGETYPE = "Image"
-IMAGE_FSTYPES = "tar.bz2 ext4 cpio.gz"
+IMAGE_FSTYPES += " tar.bz2 ext4 cpio.gz"
 
 SERIAL_CONSOLE = "115200 ttySC0"
 

--- a/meta-rcar-gen3/conf/machine/salvator-x.conf
+++ b/meta-rcar-gen3/conf/machine/salvator-x.conf
@@ -16,7 +16,7 @@ MACHINE_FEATURES = ""
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
 
 KERNEL_IMAGETYPE = "Image"
-IMAGE_FSTYPES = "tar.bz2 ext4 cpio.gz"
+IMAGE_FSTYPES += " tar.bz2 ext4 cpio.gz"
 
 SERIAL_CONSOLE = "115200 ttySC0"
 


### PR DESCRIPTION
Plain assignment overrides what is set in conf/local.conf, distro.conf etc.

Signed-off-by: Anton Gerasimov <anton@advancedtelematic.com>