### PR TITLE
FIX Kernel panic if cameras are not attached to the board

### DIFF
--- a/meta-rcar-gen3-adas/recipes-kernel/linux/linux-renesas/0030-Gen3-LVDS-cameras.patch
+++ b/meta-rcar-gen3-adas/recipes-kernel/linux/linux-renesas/0030-Gen3-LVDS-cameras.patch
@@ -2287,7 +2287,7 @@ index 0000000..6a5d0889
 +	struct max9286_priv *priv = i2c_get_clientdata(client);
 +	u8 val = 0;
 +	int timeout = priv->timeout;
-+	char timeout_str[10];
++	char timeout_str[20];
 +	int ret = 0;
 +
 +	/* Reverse channel enable */
@@ -2355,7 +2355,7 @@ index 0000000..6a5d0889
 +	priv->csi2_outord |= ((hweight8(priv->links_mask) - 1) << (idx * 2));
 +
 +out:
-+	sprintf(timeout_str, "retries=%d", priv->timeout - timeout);
++	snprintf(timeout_str, ARRAY_SIZE(timeout_str), "retries=%d", priv->timeout - timeout);
 +	dev_info(&client->dev, "link%d %s %sat 0x%x %s %s\n", idx, ser_name(priv->ser_id),
 +			       ret == -EADDRINUSE ? "already " : "", priv->max9271_addr_map[idx],
 +			       ret == -ETIMEDOUT ? "not found: timeout GMSL link establish" : "",


### PR DESCRIPTION
When cameras are not attached to the board, but defined in the dts, the max9286 driver writes a debug message like:
```[    5.404743] max9286 0-0048: link0 MAX96705 at 0x0 not found: timeout GMSL link establish retries=100```

This message is created concatenating a `sprintf(timeout_str, "retries=%d", priv->timeout - timeout);`  with the rest of the message. The issue here is that `timeout_str` is defined as a `10` char array but `retries=100` is `11` chars long. Plus `sprintf` is used while the safest `snprintf` should be preferred.

This off-by-two bug is causing the following kernel panic:
```
[    1.832691] i2c /dev entries driver
[    1.838043] i2c-rcar e6500000.i2c: probed
[    1.842458] i2c-rcar e6508000.i2c: probed
[    2.127686] max9286 0-0048: LINKs=4, LANES=4, FSYNC mode=manual, FSYNC period=3360000, PCLK edge=rising
[    5.404743] max9286 0-0048: link0 MAX96705 at 0x0 not found: timeout GMSL link establish retries=100
[    5.503538] Unable to handle kernel paging request at virtual address ffff000008060040
[    5.511420] Mem abort info:
[    5.514202]   Exception class = DABT (current EL), IL = 32 bits
[    5.520092]   SET = 0, FnV = 0
[    5.523132]   EA = 0, S1PTW = 0
[    5.526256] Data abort info:
[    5.529116]   ISV = 0, ISS = 0x00000007
[    5.532932]   CM = 0, WnR = 0
[    5.535886] swapper pgtable: 4k pages, 48-bit VAs, pgd = ffff0000092ad000
[    5.542641] [ffff000008060040] *pgd=000000077fffe803, *pud=000000077fffd803, *pmd=000000077fffc803, *pte=0000000000000000
[    5.553554] Internal error: Oops: 96000007 [#1] PREEMPT SMP
[    5.559093] Modules linked in:
[    5.562134] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 4.14.35-yocto-standard #2
[    5.569401] Hardware name: TTTech TTi-ECU-b board CPU based on r8a7795 ES2.0+ (DT)
[    5.576928] task: ffff8007368a8000 task.stack: ffff000008068000
[    5.582825] PC is at driver_probe_device+0x184/0x2d8
[    5.587760] LR is at driver_probe_device+0x184/0x2d8
[    5.592694] pc : [<ffff00000862ecec>] lr : [<ffff00000862ecec>] pstate: 40000145
[    5.600046] sp : ffff00000806bc80
[    5.603338] x29: ffff000008060030 x28: ffff0000090fac70 
[    5.608621] x27: 0000000000000007 x26: ffff00000907c068 
[    5.613903] x25: ffff000009240000 x24: 0000000000000000 
[    5.619185] x23: 0000000000000001 x22: ffff000009206560 
[    5.624467] x21: 0000000000000000 x20: ffff00000928cee8 
[    5.629748] x19: ffff800735627020 x18: 0000000000000000 
[    5.635029] x17: ffff000008b00600 x16: 0000000000000078 
[    5.640311] x15: 0000000000000000 x14: 00000001469f5aeb 
[    5.645592] x13: 0000000000000400 x12: 0000000000000400 
[    5.650873] x11: 0000000000000000 x10: 0000000000000a00 
[    5.656155] x9 : ffff00000806bb80 x8 : ffff8007368a8a60 
[    5.661436] x7 : ffff8007368a8200 x6 : 00000000000001f5 
[    5.666718] x5 : 00000001469f3400 x4 : 0000000000000025 
[    5.671999] x3 : 0000000000000000 x2 : ffff8007368a8000 
[    5.677280] x1 : ffff000009106090 x0 : 0000000000000020 
[    5.682563] Process swapper/0 (pid: 1, stack limit = 0xffff000008068000)
[    5.689225] Call trace:
[    5.691654] Exception stack(0xffff00000806bb40 to 0xffff00000806bc80)
[    5.698058] bb40: 0000000000000020 ffff000009106090 ffff8007368a8000 0000000000000000
[    5.705845] bb60: 0000000000000025 00000001469f3400 00000000000001f5 ffff8007368a8200
[    5.713630] bb80: ffff8007368a8a60 ffff00000806bb80 0000000000000a00 0000000000000000
[    5.721416] bba0: 0000000000000400 0000000000000400 00000001469f5aeb 0000000000000000
[    5.729202] bbc0: 0000000000000078 ffff000008b00600 0000000000000000 ffff800735627020
[    5.736987] bbe0: ffff00000928cee8 0000000000000000 ffff000009206560 0000000000000001
[    5.744772] bc00: 0000000000000000 ffff000009240000 ffff00000907c068 0000000000000007
[    5.752558] bc20: ffff0000090fac70 ffff000008060030 ffff00000862ecec ffff00000806bc80
[    5.760343] bc40: ffff00000862ecec 0000000040000145 ffff000008060030 ffff00000862ecec
[    5.768129] bc60: ffffffffffffffff ffff00000928cee8 ffff000008060030 ffff00000862ecec
[    5.775915] [<ffff00000862ecec>] driver_probe_device+0x184/0x2d8
[    5.781888] Code: 528000a1 94002bf2 aa1303e0 940033c0 (a94153b3) 
[    5.787961] ---[ end trace 70ebfdb42fd16722 ]---
[    5.792570] Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b
[    5.792570] 
[    5.801655] SMP: stopping secondary CPUs
[    5.805556] Kernel Offset: disabled
[    5.809022] CPU features: 0x1802004
[    5.812488] Memory Limit: none
[    5.815525] ---[ end Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b
[    5.815525] 
```

Signed-off-by: Andrea Tomassetti <andrea.tomassetti@silicon-gears.com>