### PR TITLE
fix fpsCount bug in capture

### DIFF
--- a/meta-rcar-gen3/recipes-bsp/capture/capture_1.0.bb
+++ b/meta-rcar-gen3/recipes-bsp/capture/capture_1.0.bb
@@ -6,6 +6,7 @@ S = "${WORKDIR}/capture"
 
 SRC_URI = " \
     file://capture.tar.gz \
+    file://0001-fix-fpsCount-bug.patch \
 "
 
 do_compile() {

--- a/meta-rcar-gen3/recipes-bsp/capture/files/0001-fix-fpsCount-bug.patch
+++ b/meta-rcar-gen3/recipes-bsp/capture/files/0001-fix-fpsCount-bug.patch
@@ -1,0 +1,31 @@
+From 69d35957565848406782507b6745be22dfe545e3 Mon Sep 17 00:00:00 2001
+From: bernardo araujo rodrigues <bernardo.araujo@silicon-gears.com>
+Date: Tue, 5 Feb 2019 16:41:37 +0100
+Subject: [PATCH] fix fpsCount bug
+
+---
+ capture.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/capture.c b/capture.c
+index 6fd2b85..7e06fc3 100644
+--- a/capture.c
++++ b/capture.c
+@@ -101,10 +101,12 @@ static void fpsCount(int dev)
+         struct timeval t;
+ 
+         gettimeofday(&t, NULL);
+-        usec[dev] += frames[dev]++ ? uSecElapsed(&t, &frame_time[dev]) : 0;
++	frames[dev]++;
++	usec[dev] += uSecElapsed(&t, &frame_time[dev]);
+         frame_time[dev] = t;
++
+         if (usec[dev] >= 1000000) {
+-                unsigned fps = ((unsigned long long)frames[dev] * 10000000 + usec[dev] - 1) / usec[dev];
++                unsigned fps = ((unsigned long long)frames[dev] * 10000000) / usec[dev];
+                 fprintf(stderr, "%s FPS: %3u.%1u\n", dev_name[dev], fps / 10, fps % 10);
+                 usec[dev] = 0;
+                 frames[dev] = 0;
+-- 
+2.7.4
+


### PR DESCRIPTION
I noticed the capture application was displaying a wrong FPS count.
I was getting 26.1 FPS, while I know that my cameras give one frame each 40ms, so 25 FPS was the expected result.

These changes fixed the issue.