### PR TITLE
fix fpsCount bug in capture

### DIFF
--- a/meta-rcar-gen3-adas/recipes-bsp/capture/capture_1.0.bb
+++ b/meta-rcar-gen3-adas/recipes-bsp/capture/capture_1.0.bb
@@ -6,6 +6,7 @@ S = "${WORKDIR}/capture"
 
 SRC_URI = " \
     file://capture.tar.gz \
+    file://0001-fix-fpsCount-bug.patch \
 "
 
 do_compile() {

--- a/meta-rcar-gen3-adas/recipes-bsp/capture/files/0001-fix-fpsCount-bug.patch
+++ b/meta-rcar-gen3-adas/recipes-bsp/capture/files/0001-fix-fpsCount-bug.patch
@@ -1,0 +1,32 @@
+From 69d35957565848406782507b6745be22dfe545e3 Mon Sep 17 00:00:00 2001
+From: bernardo araujo rodrigues <bernardo.araujo@silicon-gears.com>
+Date: Tue, 5 Feb 2019 16:41:37 +0100
+Subject: [PATCH] fix fpsCount bug
+
+---
+ capture.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/capture.c b/capture.c
+index 6fd2b85..30c5c1a 100644
+--- a/capture.c
++++ b/capture.c
+@@ -101,10 +101,12 @@ static void fpsCount(int dev)
+         struct timeval t;
+ 
+         gettimeofday(&t, NULL);
+-        usec[dev] += frames[dev]++ ? uSecElapsed(&t, &frame_time[dev]) : 0;
++       frames[dev]++;
++       usec[dev] += uSecElapsed(&t, &frame_time[dev]);
+         frame_time[dev] = t;
+-        if (usec[dev] >= 1000000) {
+-                unsigned fps = ((unsigned long long)frames[dev] * 10000000 + usec[dev] - 1) / usec[dev];
++
++        if (usec[dev] >= 990000) {
++                unsigned fps = ((unsigned long long)frames[dev] * 10000000) / 1000000;
+                 fprintf(stderr, "%s FPS: %3u.%1u\n", dev_name[dev], fps / 10, fps % 10);
+                 usec[dev] = 0;
+                 frames[dev] = 0;
+-- 
+2.7.4
+


### PR DESCRIPTION
The way the capture application handles fps count is somewhat imprecise.

I needed a stable and precise FPS count and investigated the source code to understand how it was being calculated inside the `fpsCount` function.

I noticed that the condition if `(usec[dev] >= 1000000)` many times would surpass 1s by a large ammount, allowing for extra frame counts.

Also, the formula used for the calculation of `fps` variable left room for large imprecisions.

Anyways, I hope this pull request is useful.