### PR TITLE
fix fpsCount bug

### DIFF
--- a/meta-rcar-gen3-adas/recipes-bsp/capture/capture_1.0.bb
+++ b/meta-rcar-gen3-adas/recipes-bsp/capture/capture_1.0.bb
@@ -6,6 +6,7 @@ S = "${WORKDIR}/capture"
 
 SRC_URI = " \
     file://capture.tar.gz \
+    file://0001-fix-fpsCount-bug.patch \
 "
 
 do_compile() {

--- a/meta-rcar-gen3-adas/recipes-bsp/capture/files/0001-fix-fpsCount-bug.patch
+++ b/meta-rcar-gen3-adas/recipes-bsp/capture/files/0001-fix-fpsCount-bug.patch
@@ -1,0 +1,31 @@
+From 2d4436aed62e9ca71c4b551a112981740d37b510 Mon Sep 17 00:00:00 2001
+From: bernardo araujo rodrigues <bernardo.araujo@silicon-gears.com>
+Date: Thu, 30 May 2019 17:41:36 +0200
+Subject: [PATCH] fix fpsCount bug
+
+---
+ capture.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/capture.c b/capture.c
+index 6fd2b85..7b74a39 100644
+--- a/capture.c
++++ b/capture.c
+@@ -101,10 +101,11 @@ static void fpsCount(int dev)
+         struct timeval t;
+ 
+         gettimeofday(&t, NULL);
+-        usec[dev] += frames[dev]++ ? uSecElapsed(&t, &frame_time[dev]) : 0;
++	frames[dev]++;
++	usec[dev] += uSecElapsed(&t, &frame_time[dev]);
+         frame_time[dev] = t;
+-        if (usec[dev] >= 1000000) {
+-                unsigned fps = ((unsigned long long)frames[dev] * 10000000 + usec[dev] - 1) / usec[dev];
++        if (usec[dev] >= 990000) {
++		unsigned fps = ((unsigned long long)frames[dev] * 10000000) / usec[dev];
+                 fprintf(stderr, "%s FPS: %3u.%1u\n", dev_name[dev], fps / 10, fps % 10);
+                 usec[dev] = 0;
+                 frames[dev] = 0;
+-- 
+2.7.4
+


### PR DESCRIPTION
I know for a fact that my camera has a 25 FPS rate. This is achieved by custom configuration at register level (fsync) of the max9286 deserializer.

This is the original `fpsCount` function with a few additional `fprintf` calls for debugging purposes:
```
 96 static void fpsCount(int dev)
 97 {
 98         static unsigned frames[N_DEVS_MAX];
 99         static struct timeval frame_time[N_DEVS_MAX];
100         static unsigned long usec[N_DEVS_MAX];
101         struct timeval t;
102 
103         gettimeofday(&t, NULL);
104         usec[dev] += frames[dev]++ ? uSecElapsed(&t, &frame_time[dev]) : 0;
105         frame_time[dev] = t;
106         if (usec[dev] >= 1000000) {
107                 unsigned fps = ((unsigned long long)frames[dev] * 10000000 + usec[dev] - 1) / usec[d    ev];
108                 fprintf(stderr, "%s FPS: %3u.%1u\n", dev_name[dev], fps / 10, fps % 10);
109                 fprintf(stderr, "%s usec: %u\n", dev_name[dev], usec[dev]);
110                 fprintf(stderr, "%s frames: %u\n\n", dev_name[dev], frames[dev]);
111 
112                 usec[dev] = 0;
113                 frames[dev] = 0;
114         }
115 }
```

This is the behaviour:

```
/dev/video0 FPS:  26.1
/dev/video0 usec: 1038142
/dev/video0 frames: 27

/dev/video0 FPS:  26.1
/dev/video0 usec: 1038285
/dev/video0 frames: 27

/dev/video0 FPS:  26.1
/dev/video0 usec: 1038459
/dev/video0 frames: 27

/dev/video0 FPS:  26.1
/dev/video0 usec: 1038352
/dev/video0 frames: 27
```

This is the `fpsCount` function after changing the way how `frames`, `usec` and `fps` variables are handled:

```
 96 static void fpsCount(int dev)
 97 {
 98         static unsigned frames[N_DEVS_MAX];
 99         static struct timeval frame_time[N_DEVS_MAX];
100         static unsigned long usec[N_DEVS_MAX];
101         struct timeval t;
102 
103         gettimeofday(&t, NULL);
104         frames[dev]++;
105         usec[dev] += uSecElapsed(&t, &frame_time[dev]);
106         frame_time[dev] = t;
107         if (usec[dev] >= 1000000) {
108                 unsigned fps = ((unsigned long long)frames[dev] * 10000000) / usec[dev];
109                 fprintf(stderr, "%s FPS: %3u.%1u\n", dev_name[dev], fps / 10, fps % 10);
110                 fprintf(stderr, "%s usec: %u\n", dev_name[dev], usec[dev]);
111                 fprintf(stderr, "%s frames: %u\n\n", dev_name[dev], frames[dev]);
112 
113                 usec[dev] = 0;
114                 frames[dev] = 0;
115         }
116 }
```

And this is the behaviour:
```
/dev/video0 FPS:  25.0
/dev/video0 usec: 1038220
/dev/video0 frames: 26

/dev/video0 FPS:  25.0
/dev/video0 usec: 1038331
/dev/video0 frames: 26

/dev/video0 FPS:  25.0
/dev/video0 usec: 1038405
/dev/video0 frames: 26

/dev/video0 FPS:  25.0
/dev/video0 usec: 1038338
/dev/video0 frames: 26
```

Finally, this is the `fpsCount` function after also changing the time limit (avoid extra frame count):
```
 96 static void fpsCount(int dev)
 97 {
 98         static unsigned frames[N_DEVS_MAX];
 99         static struct timeval frame_time[N_DEVS_MAX];
100         static unsigned long usec[N_DEVS_MAX];
101         struct timeval t;
102 
103         gettimeofday(&t, NULL);
104         frames[dev]++;
105         usec[dev] += uSecElapsed(&t, &frame_time[dev]);
106         frame_time[dev] = t;
107         if (usec[dev] >= 990000) {
108                 unsigned fps = ((unsigned long long)frames[dev] * 10000000) / usec[dev];
109                 fprintf(stderr, "%s FPS: %3u.%1u\n", dev_name[dev], fps / 10, fps % 10);
110                 fprintf(stderr, "%s usec: %u\n", dev_name[dev], usec[dev]);
111                 fprintf(stderr, "%s frames: %u\n\n", dev_name[dev], frames[dev]);
112 
113                 usec[dev] = 0;
114                 frames[dev] = 0;
115         }
116 }
```

And this is the behaviour:
```
/dev/video0 FPS:  24.9
/dev/video0 usec: 1000053
/dev/video0 frames: 25

/dev/video0 FPS:  25.0
/dev/video0 usec: 999928
/dev/video0 frames: 25

/dev/video0 FPS:  24.9
/dev/video0 usec: 1000098
/dev/video0 frames: 25

/dev/video0 FPS:  24.9
/dev/video0 usec: 1000768
/dev/video0 frames: 25

```

I am not dividing fps by 1000000 anymore (to make FPS stable), like in the previous patch.
I hope this explanation makes it clear how the code does not behave as expected. Not sure which branch to commit, so I`m doing it under v3.15.0.

Hope this is useful.